### PR TITLE
Add jsx a11y

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@ const defaults = require('./core')
 
 module.exports = {
   ...defaults,
-  env: { ...defaults.env, jest: true },
-  plugins: [...defaults.plugins, 'jest'],
   extends: [
     ...defaults.extends,
     'plugin:jest/recommended',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-eda",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Linting configuration for EDA challenges and projects",
   "author": "Enspiral Dev Academy (EDA)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-eda",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Linting configuration for EDA challenges and projects",
   "author": "Enspiral Dev Academy (EDA)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.0.0",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.28.0"

--- a/react.js
+++ b/react.js
@@ -6,8 +6,8 @@ module.exports = {
     ecmaFeatures: { jsx: true },
   },
   env: defaults.env,
-  plugins: [...defaults.plugins, 'react'],
-  extends: [...defaults.extends, 'plugin:react/recommended', 'prettier/react'],
+  plugins: [...defaults.plugins, 'react', 'jsx-a11y'],
+  extends: [...defaults.extends, 'plugin:react/recommended', 'prettier/react', 'plugin:jsx-a11y/strict'],
   settings: {
     ...defaults.settings,
     react: { version: 'detect' },
@@ -16,5 +16,7 @@ module.exports = {
   rules: {
     ...defaults.rules,
     'react/prop-types': 0,
+    'jsx-a11y/control-has-associated-label': ['error', {'ignoreElements': [], 'ignoreRoles': []}],
+    'jsx-a11y/label-has-for': 'error',
   },
 }


### PR DESCRIPTION
This works for packages running the eda/react rules, when accompanied by the related new dependency.
Sample output:
![image](https://user-images.githubusercontent.com/1482850/168504827-a6670ab8-d6b6-46df-8a4c-bcf22feaa599.png)

The results for this are not as robust as I remember them being the last time I used this plugin, though. :\